### PR TITLE
fix: set image null if no image is received

### DIFF
--- a/client/src/Components/SecondaryRegister.js
+++ b/client/src/Components/SecondaryRegister.js
@@ -12,8 +12,8 @@ const SecondaryRegister = () => {
   const [dob, setDob] = useState("");
   const [gender, setGender] = useState("");
   const [breed, setBreed] = useState(null);
-  const [value, setValue] = useState(null);
-  const [selectedOption, setSelectedOption] = useState(null);
+  // const [value, setValue] = useState(null);
+  // const [selectedOption, setSelectedOption] = useState(null);
   const [vaccinated, setvaccinated] = useState("");
   const [image, setImage] = useState(null);
   const [text, setText] = useState("");
@@ -47,10 +47,10 @@ const SecondaryRegister = () => {
       toast.error("Please select if vaccinated");
       return;
     }
-    if (image === null) {
-      toast.error("Please enter a profile picture");
-      return;
-    }
+    // if (image === null) {
+    //   toast.error("Please enter a profile picture");
+    //   return;
+    // }
 
     try {
       const formData = new FormData();

--- a/server/Controllers/AuthController.js
+++ b/server/Controllers/AuthController.js
@@ -107,8 +107,16 @@ cloudinary.config({
 module.exports.SecondaryRegister= async(req,res) =>{
     try {
         const { name, dob, breed, gender, vaccinated, bio } = req.body;
-        const imageFilePath = req.file.path;
-        const cldRes = await handleUpload(imageFilePath);
+        // const imageFilePath = req.file.path;
+
+        let imageFilePath = null;
+        let cldRes = null;
+        if (req.file && req.file.path) {
+          imageFilePath = req.file.path;
+          cldRes = await handleUpload(imageFilePath);
+        }
+
+        // const cldRes = await handleUpload(imageFilePath);
         const userID = req.cookies.userID;
     
         const newProfile = new ProfileModel({
@@ -117,7 +125,8 @@ module.exports.SecondaryRegister= async(req,res) =>{
           breed,
           gender,
           vaccinated,
-          image: cldRes.secure_url,
+          // image: cldRes.secure_url,
+          image: imageFilePath ? cldRes.secure_url : null, 
           bio,  
           id: userID,
         });


### PR DESCRIPTION
You can now create the account with image null(handled the backend blockers)
![image](https://github.com/DevanshSahni/Wiggles/assets/108670241/f357eeeb-0e4e-4915-911f-61817705ba3e)

