### PR TITLE
fix(loginPopUp): add media query for small screen size devices

### DIFF
--- a/client/src/components/Footer.js
+++ b/client/src/components/Footer.js
@@ -6,10 +6,12 @@ import { AiFillGithub } from "react-icons/ai";
 import "../styles/footer.css";
 import { postData } from "../utils/api";
 import { toast } from "react-toastify";
+import { useSelector } from "react-redux";
 
 export default function Footer() {
   const navigate = useNavigate();
   const dispatch = useDispatch();
+  const loggedIn = useSelector((state) => state.userLogin.isLoggedIn);
 
   const logout = async () => {
     try {
@@ -70,7 +72,7 @@ export default function Footer() {
               <Link className="supportLinks" to="/explore">
                 Explore
               </Link>
-              <div className="supportLinks" onClick={logout}>
+              <div className="supportLinks" onClick={logout} style={loggedIn ? {display: "initial"} : {display: "none"}}>
                 Logout
               </div>
             </div>

--- a/client/src/components/Navbar.js
+++ b/client/src/components/Navbar.js
@@ -105,6 +105,7 @@ const Navbar = () => {
           <Link
             to="/profile"
             className="navbarLinksProfile"
+            style={loggedIn ? {display: "initial"} : {display: "none"}}
             onClick={closeMenu}
           >
             <CgProfile className="reactIcon" />
@@ -138,7 +139,11 @@ const Navbar = () => {
             <HiOutlineMail className="reactIcon" />
             &nbsp;Contact
           </Link>
-          <Link className="navbarLinksContact" onClick={logout}>
+          <Link 
+            className="navbarLinksContact" 
+            style={loggedIn ? {display: "initial"} : {display: "none"}}
+            onClick={logout}
+          >
             <TbLogout />
             &nbsp;Logout
           </Link>

--- a/client/src/styles/loginComponent.css
+++ b/client/src/styles/loginComponent.css
@@ -100,3 +100,27 @@
   justify-content: center;
   padding: 20px;
 }
+
+@media (max-width:960px) {
+  .loginComponentContainer {
+    padding: 1.75rem;
+  }
+
+  .loginComponentContainer h2 {
+    font-size: 1.5rem;;
+  }
+
+  .loginComponentForm {
+    width: 100%;
+    padding: 0px;
+  }
+
+  .secondaryLogin span {
+    font-size: 1rem;
+  }
+
+  .divider {
+    width: 100%;
+    margin: 15px auto 0;
+  }
+}


### PR DESCRIPTION
- hide `profile` and `logout` links in the hamburger and footer when user is not logged in